### PR TITLE
Ensure user_id is an integer

### DIFF
--- a/src/app/Models/Avatar.php
+++ b/src/app/Models/Avatar.php
@@ -21,6 +21,9 @@ class Avatar extends Model implements Attachable
 
     protected $fillable = ['user_id', 'original_name', 'saved_name'];
     protected $hidden = ['user_id', 'created_at', 'updated_at'];
+    protected $casts = [
+        'user_id' => 'int',
+    ];
 
     public function user()
     {


### PR DESCRIPTION
Caused type-mismatch when comparing to `$user->id` in `AvatarPolicy->update(...)` during tests on certain configurations (both windows & linux)